### PR TITLE
Feature/tracking

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,9 +1,14 @@
 name: CI
 
-on: 
+on:
   push:
+    branches:
+      - main
   pull_request:
-    types: [opened]
+    branches:
+      - main
+    types:
+      - opened
 
 jobs:
   ci:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, "3.0"]
+        ruby: [2.6, 2.7, 3.0]
     name: Build / Test
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, "3.0"]
     name: Build / Test
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+    types: [opened]
 
 jobs:
   ci:

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@
 .vscode
 .idea
 /bin/bundle
-/bin/**
 
 # Locals
 foo.rb

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@
 .idea
 /bin/bundle
 /bin/**
+
+# Locals
+foo.rb
+bar.rb
+baz.rb

--- a/.pryrc
+++ b/.pryrc
@@ -49,7 +49,7 @@ begin
     multiline: true,
   }
   AwesomePrint.pry!
-rescue LoadError => err
+rescue err
   puts "gem install awesome_print  # <-- highly recommended"
 end
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - tmp/**/*
     - vendor/**/*
     - lib/shipengine/utils/base58.rb
+    - !ruby/regexp /(foo|bar|baz)\.rb/
 
 Style/Documentation:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
 [![ShipEngine](https://shipengine.github.io/img/shipengine-logo-wide.png)](https://shipengine.com)
 
-The Official Ruby SDK for ShipEngine
+ShipEngine Ruby SDK
+===================
+
+> :warning: **WARNING**: This is alpha software under active development and it is not ready for consumer use.
+
+The Official Ruby SDK for [ShipEngine API](https://shipengine.com) offering low-level access as well as convenience methods.
+
+Quick Start
+===========
+
+Install ShipEngine via [RubyGems](https://rubygems.org/)
+```bash
+gem install shipengine_sdk
+```
+- The only configuration requirement is an [API Key](https://www.shipengine.com/docs/auth/#api-keys).
+
+Methods
+-------
+- [validate_address]() - Indicates whether the provided address is valid. If the
+  address is valid, the method returns a normalized version of the address based on the standards of the country in
+  which the address resides.
+- [normalize_address]() - Returns a normalized, or standardized, version of the
+  address. If the address cannot be normalized, an error is returned.
+- [track_package_by_id]() - Track a package by `packageId` (Ideal if you create a shipping label via ShipEngine).
+- [track_package_by_tracking_number]() - Track a package by `carrierCode` and `trackingNumber`.
+
+
+Class Objects
+-------------
+- [ShipEngine]() - A configurable entry point to the ShipEngine API SDK, this class provides convenience methods
+  for various ShipEngine API Services.
+
+Instantiate ShipEngine Class
+----------------------------
+```ruby
+require "shipengine"
+
+api_key = ENV["SHIPENGINE_API_KEY"]
+
+shipengine = ShipEngine.new(api_key)
+```
 
 # Decisions
 
@@ -17,9 +57,15 @@ The Official Ruby SDK for ShipEngine
 
 - coercing empty strings from Address Validation to nil?
 
-## Installation
+## Install dependencies
+- You will need to `gem install bundler` before using the following command to install dependencies from the Gemfile.
+```bash
+bundle
+```
 
-- `bundle`
+Testing
+-------
+
 
 ## Commands
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "shipengine"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+shipengine = ShipEngine::Client.new("baz")
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require "pry"
+Pry.start
+
+# require "irb"
+
+ENV["USE_SIMENGINE"] = "true"
+
+# IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/shipengine.rb
+++ b/lib/shipengine.rb
@@ -29,8 +29,8 @@ module ShipEngine
 
       internal_client = InternalClient.new(@configuration)
       @address = Domain::Address.new(internal_client)
-      @package = Domain::Package.new(internal_client)
       @carriers = Domain::Carrier.new(internal_client)
+      @package = Domain::Package.new(internal_client, @carriers)
     end
 
     # wrap methods in a block to "catch" and emit the errors

--- a/lib/shipengine.rb
+++ b/lib/shipengine.rb
@@ -3,6 +3,8 @@
 # for client class
 require "shipengine/internal_client"
 require "shipengine/domain"
+require "shipengine/emitter"
+require "shipengine/configuration"
 
 # just for exporting
 require "shipengine/version"
@@ -12,131 +14,6 @@ require "shipengine/constants"
 require "observer"
 
 module ShipEngine
-  class Configuration
-    attr_accessor :api_key, :retries, :base_url, :timeout, :page_size, :emitter
-
-    def initialize(api_key:, retries: nil, timeout: nil, page_size: nil, base_url: nil, emitter: nil)
-      @api_key = api_key
-      @base_url = base_url || Constants.get_simengine_base_url()
-      @retries = retries || 1
-      @timeout = timeout || 30_000
-      @page_size = page_size || 50
-      @emitter = emitter || Emitter::EventEmitter.new
-      validate
-    end
-
-    # @param opts [Hash] the options to create a message with.
-    # @option opts [String] :ap The subject
-    # @option opts [String] :from ('nobody') From address
-    # @option opts [String] :to Recipient email
-    # @option opts [String] :body ('') The email's body
-    def merge(config)
-      copy = clone
-      copy.api_key = config[:api_key] if config.key?(:api_key)
-      copy.base_url = config[:base_url] if config.key?(:base_url)
-      copy.retries =  config[:retries] if config.key?(:retries)
-      copy.timeout =  config[:timeout] if config.key?(:timeout)
-      copy.page_size = config[:page_size] if config.key?(:page_size)
-      copy.emitter = config[:emitter] if config.key?(:emitter)
-      copy.validate
-      copy
-    end
-
-    # since the fields in the class are mutable, we should be able to validate them at any time.
-    protected
-
-    def validate
-      Utils::Validate.str("A ShipEngine API key", @api_key)
-      Utils::Validate.str("Base URL", @base_url)
-      Utils::Validate.non_neg_int("Retries", @retries)
-      Utils::Validate.positive_int("Timeout", @timeout)
-      Utils::Validate.positive_int("Page size", @page_size)
-    end
-  end
-
-  module Emitter
-    class Event
-      require "date"
-      require "uri"
-      attr_reader :datetime, :type, :message
-      def initialize(type:, message:)
-        @type = type
-        @message = message
-        @datetime = Time.now
-      end
-    end
-
-    class EventType
-      RESPONSE_RECEIVED = "response_received"
-      REQUEST_SENT = "request_sent"
-      ERROR = "error"
-    end
-
-    class ErrorEvent < Event
-      attr_reader :request_id, :error_source, :error_code, :error_type
-      def initialize(message:, request_id: nil, error_source: nil, error_code: nil, error_type:)
-        super(type: EventType::ERROR, message: message)
-        @request_id = request_id
-        @error_source = error_source
-        @error_code = error_code
-        @error_type = error_type
-      end
-    end
-
-    class HttpEvent < Event
-      attr_reader :request_id, :retry_attempt, :body, :headers, :url
-      def initialize(type:, message:, request_id:, body:, retry_attempt:, headers:, url:)
-        super(type: type, message: message)
-        url = URI(url)
-        @url = url
-        @headers = headers
-        @request_id = request_id
-        @retry_attempt = retry_attempt
-        @body = body
-      end
-    end
-
-    class RequestSentEvent < HttpEvent
-      attr_reader :timeout
-      def initialize(message:, request_id:, body:, retry_attempt:, headers:, url:, timeout:)
-        super(type: EventType::REQUEST_SENT, message: message, request_id: request_id, body: body, headers: headers, url: url, retry_attempt: retry_attempt)
-        # The amount of time that will be allowed before this request times out. For languages that have a native time span data type, this should be that type. Otherwise, it should be an integer that represents the number of milliseconds.
-        @timeout = timeout
-      end
-    end
-
-    class ResponseReceivedEvent < HttpEvent
-      attr_reader :elapsed, :status_code
-      def initialize(message:, request_id:, body:, retry_attempt:, headers:, url:, elapsed:, status_code:)
-        super(type: EventType::RESPONSE_RECEIVED, message: message, request_id: request_id, body: body, headers: headers, url: url, retry_attempt: retry_attempt)
-        # The amount of time that elapsed between when the request was sent and when the response was received. For languages that have a native time span data type, this should be that type. Otherwise, it should be an integer that represents the number of milliseconds.
-        @elapsed = elapsed
-        @status_code = status_code
-      end
-    end
-
-    # @abstract Subclass and override {#on_request_sent} / {#on_response_received} / {#on_error} # to implement a custom EventEmitter
-    class EventEmitter
-      #
-      # Implement this method to subscribe to `on_request_sent` events.
-      #
-      # @param request_sent_event [::ShipEngine::Emitter::RequestSentEvent]
-      def on_request_sent(request_sent_event); end
-
-      #
-      # Implement this method to subscribe to `on_response_received` events.
-      #
-      # @param request_sent_event [::ShipEngine::Emitter::ResponseReceivedEvent]
-      def on_response_received(response_received_event); end
-
-      #
-      # Implement this method to subscribe to `error` events.
-
-      # @param request_sent_event [::ShipEngine::Emitter::ErrorEvent]
-      def on_error(error_event); end
-    end
-  end
-
   class Client
     attr_accessor :configuration
 
@@ -161,15 +38,17 @@ module ShipEngine
     def with_emit_error(emitter)
       yield
     rescue ::ShipEngine::Exceptions::ShipEngineError => err
-      emitter ||= configuration.emitter
-      error_event = ShipEngine::Emitter::ErrorEvent.new(
-        message: err.message,
-        request_id: err.request_id,
-        error_source: err.source,
-        error_code: err.code,
-        error_type: err.type,
-      )
-      emitter.on_error(error_event)
+      emitter = @configuration.emitter
+      if emitter
+        error_event = ShipEngine::Emitter::ErrorEvent.new(
+          message: err.message,
+          request_id: err.request_id,
+          error_source: err.source,
+          error_code: err.code,
+          error_type: err.type,
+        )
+        emitter.on_error(error_event)
+      end
       raise err
     end
 
@@ -215,12 +94,34 @@ module ShipEngine
       end
     end
 
+    # Track package by package id (recommended)
+    #
+    # @param tracking_number [String] <description>
+    # @param config [Hash]
+    # @option config [String?] :api_key
+    # @option config [String?] :base_url
+    # @option config [Number?] :retries
+    # @option config [Number?] :timeout
+    #
+    # @return [::ShipEngine::TrackPackageResult]
+    #
     def track_package_by_id(package_id, config = {})
       with_emit_error(config[:emitter]) do
         @package.track_by_id(package_id, config)
       end
     end
 
+    #
+    # Track package by tracking number. Tracking by package_id is preferred [@see #track_package_by_id]
+    # @param tracking_number [String] <description>
+    # @param config [Hash]
+    # @option config [String?] :api_key
+    # @option config [String?] :base_url
+    # @option config [Number?] :retries
+    # @option config [Number?] :timeout
+    #
+    # @return [::ShipEngine::TrackPackageResult]
+    #
     def track_package_by_tracking_number(tracking_number, carrier_code, config = {})
       with_emit_error(config[:emitter]) do
         @package.track_by_tracking_number(tracking_number, carrier_code, config)

--- a/lib/shipengine/configuration.rb
+++ b/lib/shipengine/configuration.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+module ShipEngine
+  class Configuration
+    attr_accessor :api_key, :retries, :base_url, :timeout, :page_size, :emitter
+
+    def initialize(api_key:, retries: nil, timeout: nil, page_size: nil, base_url: nil, emitter: nil)
+      @api_key = api_key
+      @base_url = base_url || Constants.base_url
+      @retries = retries || 1
+      @timeout = timeout || 30_000
+      @page_size = page_size || 50
+      @emitter = emitter
+      validate
+    end
+
+    # @param opts [Hash] the options to create a message with.
+    # @option opts [String] :ap The subject
+    # @option opts [String] :from ('nobody') From address
+    # @option opts [String] :to Recipient email
+    # @option opts [String] :body ('') The email's bod
+    def merge(config)
+      copy = clone
+      copy.api_key = config[:api_key] if config.key?(:api_key)
+      copy.base_url = config[:base_url] if config.key?(:base_url)
+      copy.retries =  config[:retries] if config.key?(:retries)
+      copy.timeout =  config[:timeout] if config.key?(:timeout)
+      copy.page_size = config[:page_size] if config.key?(:page_size)
+      copy.emitter = config[:emitter] if config.key?(:emitter)
+      copy.validate
+      copy
+    end
+
+    # since the fields in the class are mutable, we should be able to validate them at any time.
+    protected
+
+    def validate
+      Utils::Validate.str("A ShipEngine API key", @api_key)
+      Utils::Validate.str("Base URL", @base_url)
+      Utils::Validate.non_neg_int("Retries", @retries)
+      Utils::Validate.positive_int("Timeout", @timeout)
+      Utils::Validate.positive_int("Page size", @page_size)
+    end
+  end
+end

--- a/lib/shipengine/constants/base.rb
+++ b/lib/shipengine/constants/base.rb
@@ -4,7 +4,7 @@ module ShipEngine
     SIMENGINE_URL = "https://simengine.herokuapp.com/jsonrpc"
     PROD_URL = "https://api.shipengine.com"
 
-    def self.get_simengine_base_url
+    def self.base_url
       ENV["USE_SIMENGINE"] == "true" ? ShipEngine::Constants::SIMENGINE_URL : ShipEngine::Constants::PROD_URL
     end
   end

--- a/lib/shipengine/constants/base.rb
+++ b/lib/shipengine/constants/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module ShipEngine
   module Constants
+    API_KEY = "baz"
     SIMENGINE_URL = "https://simengine.herokuapp.com/jsonrpc"
     PROD_URL = "https://api.shipengine.com"
 

--- a/lib/shipengine/domain/address.rb
+++ b/lib/shipengine/domain/address.rb
@@ -17,7 +17,7 @@ module ShipEngine
     attr_reader :normalized_address, :errors, :warnings, :info, :request_id
 
     # @param [Boolean] valid
-    # @param [NormalizedAddress] normalized_address
+    # @param [NormalizedAddress?] normalized_address
     # @param [Array<AddressValidationMessage>] errors
     # @param [Array<AddressValidationMessage>] warnings
     # @param [Array<AddressValidationMessage>] info

--- a/lib/shipengine/domain/carriers.rb
+++ b/lib/shipengine/domain/carriers.rb
@@ -20,6 +20,7 @@ module ShipEngine
       "usps" => "U.S. Postal Service",
       "stamps_com" => "Stamps.com",
     }.freeze
+    # TODO: update above carrier map to be current, missing several carriers.
   end
 
   class CarrierAccount
@@ -56,8 +57,6 @@ module ShipEngine
           )
         end
       end
-
-      # TODO: move get_carrier_account() in here
     end
   end
 end

--- a/lib/shipengine/domain/carriers.rb
+++ b/lib/shipengine/domain/carriers.rb
@@ -2,9 +2,11 @@
 
 require "shipengine/utils/validate"
 require "shipengine/constants"
+require "shipengine/utils/pretty_print"
 
 module ShipEngine
   class Carrier
+    include ::ShipEngine::Utils::PrettyPrint
     attr_reader :code, :name
 
     # @param code [string] e.g. 'ups' | 'fedex'
@@ -24,6 +26,7 @@ module ShipEngine
   end
 
   class CarrierAccount
+    include ::ShipEngine::Utils::PrettyPrint
     attr_reader :carrier, :account_id, :account_number, :name
 
     # @param carrier [Carrier]

--- a/lib/shipengine/domain/carriers.rb
+++ b/lib/shipengine/domain/carriers.rb
@@ -56,6 +56,8 @@ module ShipEngine
           )
         end
       end
+
+      # TODO: move get_carrier_account() in here
     end
   end
 end

--- a/lib/shipengine/domain/package.rb
+++ b/lib/shipengine/domain/package.rb
@@ -29,7 +29,7 @@ module ShipEngine
       @shipment_id = shipment_id
       @carrier_account_id = carrier_account_id
       @carrier_account = get_carrier_account(carrier_account, @carrier_account_id)
-      @carrier = carrier_account.carrier
+      @carrier = @carrier_account.carrier
       @estimated_delivery_date = estimated_delivery_datetime
       @actual_delivery_date = actual_delivery_datetime
     end
@@ -38,10 +38,11 @@ module ShipEngine
 
     def get_carrier_account(carrier, account_id)
       target_carrier = []
+
       carrier_accounts = @carriers.list_accounts(config: @config, carrier_code: carrier)
       carrier_accounts.each do |n|
         if account_id == n.account_id
-          carrier_accounts << target_carrier
+          target_carrier << n
         end
       end
       target_carrier[0]

--- a/lib/shipengine/domain/package.rb
+++ b/lib/shipengine/domain/package.rb
@@ -103,6 +103,8 @@ module ShipEngine
     def has_errors?
       @has_errors
     end
+
+    # TODO: .to_s() override
   end
 
   # TODO: make private
@@ -142,7 +144,7 @@ module ShipEngine
     weight = package["weight"]
     dimensions = package["dimensions"]
     events = events.map { |e| map_event(e) }
-    errors = events.select { |event| event.status == 'Exception' }
+    errors = events.select { |event| event.status == "Exception" }
 
     TrackPackageResult.new(
       latest_event: events[-1],
@@ -163,10 +165,10 @@ module ShipEngine
       ),
 
       errors: errors,
-      has_errors: errors.length > 0, # TODO
+      has_errors: !errors.empty?,
 
       shipment: shipment && TrackPackageShipment.new(
-        carrier_id: shipment["carrierID"],
+        carrier_id: shipment["carrierAccountID"],
         carrier_account: shipment["carrierAccount"],
         carrier: ::ShipEngine::Carrier.new(shipment["carrierCode"]),
         shipment_id: shipment["shipmentID"],

--- a/lib/shipengine/domain/package.rb
+++ b/lib/shipengine/domain/package.rb
@@ -3,6 +3,178 @@
 require "shipengine/utils/validate"
 
 module ShipEngine
+  class TrackPackageLocationCoordinates
+    attr_reader :latitude, :longitude
+    def initialize(latitude:, longitude:)
+      @latitude = latitude
+      @longitude = longitude
+    end
+  end
+
+  class TrackPackageShipment
+    attr_reader :shipment_id, :carrier_id, :carrier_account, :carrier, :estimated_delivery_datetime, :actual_delivery_datetime
+    def initialize(shipment_id:, carrier_id:, carrier_account:, carrier:, estimated_delivery_datetime:, actual_delivery_datetime:)
+      @shipment_id = shipment_id
+      @carrier_id = carrier_id
+      @carrier_account = carrier_account
+      @carrier = carrier
+      @estimated_delivery_date = estimated_delivery_datetime
+      @actual_delivery_date = actual_delivery_datetime
+    end
+  end
+
+  class TrackPackageLocation
+    attr_reader :postal_code, :country_code, :city_locality, :coordinates
+    def initialize(postal_code:, country_code:, city_locality:, coordinates:)
+      @postal_code = postal_code
+      @country_code = country_code
+      @city_locality = city_locality
+      @coordinates = coordinates
+    end
+  end
+
+  class TrackPackageEvent
+    attr_reader :datetime, :carrier_datetime, :status, :description, :carrier_status_code, :carrier_detail_code, :signer, :location
+    def initialize(datetime:, carrier_datetime:, status:, description:, carrier_status_code:, carrier_detail_code:, signer:, location:)
+      @datetime = datetime
+      @carrier_datetime = carrier_datetime
+      @status = status
+      @description = description
+      @carrier_status_code = carrier_status_code
+      @carrier_detail_code = carrier_detail_code
+      @signer = signer
+      @location = location
+    end
+  end
+
+  class TrackPackageWeight
+    attr_reader :unit, :value
+    def initialize(unit:, value:)
+      @unit = unit
+      @value = value
+    end
+  end
+
+  class TrackPackageDimensions
+    attr_reader :unit, :height, :length, :width
+    def initialize(unit:, height:, length:, width:)
+      @unit = unit
+      @height = height
+      @width = width
+      @length = length
+    end
+  end
+
+  class TrackPackagePackage
+    attr_reader :package_id, :tracking_number, :tracking_url, :weight, :dimensions
+
+    # @param tracking_number [String]
+    # @param tracking_url [String]
+    # @param weight [Number]
+    # @param dimensions [::TrackPackageDimensions]
+    #
+    def initialize(package_id:, tracking_number:, tracking_url:, weight:, dimensions:)
+      @package_id = package_id
+      @tracking_number = tracking_number
+      @tracking_url = URI(tracking_url)
+      @weight = weight
+      @dimensions = dimensions
+    end
+  end
+
+  class TrackPackageResult
+    attr_reader :package, :shipment, :events, :latest_event, :errors
+    def initialize(
+      package:,
+      shipment:,
+      events:,
+      latest_event:,
+      errors:,
+      has_errors:
+    )
+      @shipment = shipment
+      @package = package
+      @events = events
+      @latest_event = latest_event
+      @errors = errors
+      @has_errors = has_errors
+    end
+
+    def has_errors?
+      @has_errors
+    end
+  end
+
+  # TODO: make private
+
+  def self.get_actual_delivery_date(events)
+    delivered_events = events.filter { |e| e.status.downcase == "delivered" }
+    delivered_events[-1]
+  end
+
+  # TODO: make private
+  def self.map_event(event)
+    loc = event["location"]
+    coordinates = loc && loc["coordinates"]
+    TrackPackageEvent.new(
+      datetime: event["timestamp"],
+      carrier_datetime: event["carrierTimestamp"],
+      status: event["status"],
+      description: event["description"],
+      carrier_status_code: event["carrierStatusCode"],
+      carrier_detail_code: event["carrierDetailCode"],
+      signer: event["signer"],
+      location: loc && TrackPackageLocation.new(
+        city_locality: loc["cityLocality"],
+        postal_code: loc["postalCode"],
+        country_code: loc["countryCode"],
+        coordinates: coordinates && TrackPackageLocationCoordinates.new(
+          latitude: coordinates["latitude"],
+          longitude: coordinates["longitude"]
+        )
+      )
+    )
+  end
+
+  # TODO: make private
+  def self.map_track_package_result(result)
+    shipment, package, events, request_id = result.values_at("shipment", "package", "events", "id")
+    weight = package["weight"]
+    dimensions = package["dimensions"]
+    events = events.map { |e| map_event(e) }
+    TrackPackageResult.new(
+      latest_event: events[-1],
+      package: TrackPackagePackage.new(
+        package_id: package["packageID"],
+        tracking_number: package["trackingNumber"],
+        tracking_url: package["trackingURL"],
+        weight: weight && TrackPackageWeight.new(
+          value: weight["value"],
+          unit: weight["unit"]
+        ),
+        dimensions: dimensions && TrackPackageDimensions.new(
+          length: dimensions["length"],
+          width: dimensions["width"],
+          height: dimensions["height"],
+          unit: dimensions["unit"]
+        )
+      ),
+
+      errors: [], # TODO
+      has_errors: false, # TODO
+
+      shipment: shipment && TrackPackageShipment.new(
+        carrier_id: shipment["carrierID"],
+        carrier_account: shipment["carrierAccount"],
+        carrier: ::ShipEngine::Carrier.new(shipment["carrierCode"]),
+        shipment_id: shipment["shipmentID"],
+        estimated_delivery_datetime: shipment["estimatedDelivery"],
+        actual_delivery_datetime: get_actual_delivery_date(events)
+      ),
+      events: events
+    )
+  end
+
   module Domain
     class Package
       # @param [ShipEngine::InternalClient] internal_client
@@ -15,8 +187,10 @@ module ShipEngine
       # @return [ShipEngine::Domain::Package::TrackPackageResult]
       def track_by_id(package_id, config = {})
         Utils::Validate.not_nil_or_empty_str(package_id, "A package id")
-        @internal_client.make_request("package.track.v1", { packageID: package_id }, config)
+        response = @internal_client.make_request("package.track.v1", { packageID: package_id }, config)
+        ::ShipEngine.map_track_package_result(response.result)
       end
+      # TrackPackageResult.new(package:  )
 
       # @param [String] carrier_code - e.g. UPS
       # @param [String]  tracking_number - e.g 1Z9999999999999999
@@ -24,8 +198,8 @@ module ShipEngine
       def track_by_tracking_number(tracking_number, carrier_code, config = {})
         Utils::Validate.not_nil_or_empty_str(tracking_number, "A tracking number")
         Utils::Validate.not_nil_or_empty_str(carrier_code, "A carrier code")
-        @internal_client.make_request("package.track.v1",
-          { trackingNumber: tracking_number, carrierCode: carrier_code }, config)
+        response = @internal_client.make_request("package.track.v1", { trackingNumber: tracking_number, carrierCode: carrier_code }, config)
+        ::ShipEngine.map_track_package_result(response.result)
       end
     end
   end

--- a/lib/shipengine/domain/package.rb
+++ b/lib/shipengine/domain/package.rb
@@ -142,6 +142,8 @@ module ShipEngine
     weight = package["weight"]
     dimensions = package["dimensions"]
     events = events.map { |e| map_event(e) }
+    errors = events.select { |event| event.status == 'Exception' }
+
     TrackPackageResult.new(
       latest_event: events[-1],
       package: TrackPackagePackage.new(
@@ -160,8 +162,8 @@ module ShipEngine
         )
       ),
 
-      errors: [], # TODO
-      has_errors: false, # TODO
+      errors: errors,
+      has_errors: errors.length > 0, # TODO
 
       shipment: shipment && TrackPackageShipment.new(
         carrier_id: shipment["carrierID"],

--- a/lib/shipengine/emitter.rb
+++ b/lib/shipengine/emitter.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+module ShipEngine
+  module Emitter
+    class Event
+      require "date"
+      require "uri"
+      attr_reader :datetime, :type, :message
+      def initialize(type:, message:)
+        @type = type
+        @message = message
+        @datetime = Time.now
+      end
+    end
+
+    class EventType
+      RESPONSE_RECEIVED = "response_received"
+      REQUEST_SENT = "request_sent"
+      ERROR = "error"
+    end
+
+    class ErrorEvent < Event
+      attr_reader :request_id, :error_source, :error_code, :error_type
+      def initialize(message:, request_id: nil, error_source: nil, error_code: nil, error_type:)
+        super(type: EventType::ERROR, message: message)
+        @request_id = request_id
+        @error_source = error_source
+        @error_code = error_code
+        @error_type = error_type
+      end
+    end
+
+    class HttpEvent < Event
+      attr_reader :request_id, :retry_attempt, :body, :headers, :url
+      def initialize(type:, message:, request_id:, body:, retry_attempt:, headers:, url:)
+        super(type: type, message: message)
+        url = URI(url)
+        @url = url
+        @headers = headers
+        @request_id = request_id
+        @retry_attempt = retry_attempt
+        @body = body
+      end
+    end
+
+    class RequestSentEvent < HttpEvent
+      attr_reader :timeout
+      def initialize(message:, request_id:, body:, retry_attempt:, headers:, url:, timeout:)
+        super(type: EventType::REQUEST_SENT, message: message, request_id: request_id, body: body, headers: headers, url: url, retry_attempt: retry_attempt)
+        # The amount of time that will be allowed before this request times out. For languages that have a native time span data type, this should be that type. Otherwise, it should be an integer that represents the number of milliseconds.
+        @timeout = timeout
+      end
+    end
+
+    class ResponseReceivedEvent < HttpEvent
+      attr_reader :elapsed, :status_code
+      def initialize(message:, request_id:, body:, retry_attempt:, headers:, url:, elapsed:, status_code:)
+        super(type: EventType::RESPONSE_RECEIVED, message: message, request_id: request_id, body: body, headers: headers, url: url, retry_attempt: retry_attempt)
+        # The amount of time that elapsed between when the request was sent and when the response was received. For languages that have a native time span data type, this should be that type. Otherwise, it should be an integer that represents the number of milliseconds.
+        @elapsed = elapsed
+        @status_code = status_code
+      end
+    end
+
+    # @abstract Subclass and override {#on_request_sent} / {#on_response_received} / {#on_error} # to implement a custom EventEmitter
+    class EventEmitter
+      #
+      # Implement this method to subscribe to `on_request_sent` events.
+      #
+      # @param request_sent_event [::ShipEngine::Emitter::RequestSentEvent]
+      def on_request_sent(request_sent_event); end
+
+      #
+      # Implement this method to subscribe to `on_response_received` events.
+      #
+      # @param request_sent_event [::ShipEngine::Emitter::ResponseReceivedEvent]
+      def on_response_received(response_received_event); end
+
+      #
+      # Implement this method to subscribe to `error` events.
+
+      # @param request_sent_event [::ShipEngine::Emitter::ErrorEvent]
+      def on_error(error_event); end
+    end
+  end
+end

--- a/lib/shipengine/emitter.rb
+++ b/lib/shipengine/emitter.rb
@@ -45,7 +45,15 @@ module ShipEngine
     class RequestSentEvent < HttpEvent
       attr_reader :timeout
       def initialize(message:, request_id:, body:, retry_attempt:, headers:, url:, timeout:)
-        super(type: EventType::REQUEST_SENT, message: message, request_id: request_id, body: body, headers: headers, url: url, retry_attempt: retry_attempt)
+        super(
+          type: EventType::REQUEST_SENT,
+          message: message,
+          request_id: request_id,
+          body: body,
+          headers: headers,
+          url: url,
+          retry_attempt: retry_attempt
+        )
         # The amount of time that will be allowed before this request times out. For languages that have a native time span data type, this should be that type. Otherwise, it should be an integer that represents the number of milliseconds.
         @timeout = timeout
       end
@@ -54,7 +62,15 @@ module ShipEngine
     class ResponseReceivedEvent < HttpEvent
       attr_reader :elapsed, :status_code
       def initialize(message:, request_id:, body:, retry_attempt:, headers:, url:, elapsed:, status_code:)
-        super(type: EventType::RESPONSE_RECEIVED, message: message, request_id: request_id, body: body, headers: headers, url: url, retry_attempt: retry_attempt)
+        super(
+          type: EventType::RESPONSE_RECEIVED,
+          message: message,
+          request_id: request_id,
+          body: body,
+          headers: headers,
+          url: url,
+          retry_attempt: retry_attempt
+        )
         # The amount of time that elapsed between when the request was sent and when the response was received. For languages that have a native time span data type, this should be that type. Otherwise, it should be an integer that represents the number of milliseconds.
         @elapsed = elapsed
         @status_code = status_code

--- a/lib/shipengine/internal_client.rb
+++ b/lib/shipengine/internal_client.rb
@@ -202,7 +202,6 @@ module ShipEngine
         req.body = build_jsonrpc_request_body(method, params)
       end
       assert_shipengine_rpc_success(response, config_with_overrides)
-
       result, id = response.body.values_at("result", "id")
       InternalClientResponseSuccess.new(result: result, request_id: id)
     end
@@ -217,7 +216,7 @@ module ShipEngine
       api_key = config.api_key
       timeout = config.timeout
 
-      connection = Faraday.new(url: base_url) do |conn|
+      Faraday.new(url: base_url) do |conn|
         conn.headers = {
           "API-Key" => api_key,
           "Content-Type" => "application/json",
@@ -237,8 +236,6 @@ module ShipEngine
         conn.response(:json)
         config.emitter && conn.response(:response_received, config)
       end
-
-      connection
     end
 
     # @param method [String] e.g. "address.validate.v1"

--- a/lib/shipengine/utils/pretty_print.rb
+++ b/lib/shipengine/utils/pretty_print.rb
@@ -3,7 +3,7 @@
 module ShipEngine
   module Utils
     class PrettyPrint
-      def self.to_hash
+      def self.to_s
         hash = {}
         instance_variables.each { |n| hash[n.to_s.delete("@")] = instance_variable_get(n) }
         hash

--- a/lib/shipengine/utils/pretty_print.rb
+++ b/lib/shipengine/utils/pretty_print.rb
@@ -5,10 +5,19 @@ require "json"
 module ShipEngine
   module Utils
     module PrettyPrint
+
+      # This will be used to add a *to_s* method override
+      # to each class that *includes* the *PrettyPrint* module.
+      # This method returns a *JSON String* so one can easily inspect
+      # the contents of a given object.
       def to_s
         JSON.pretty_generate(to_hash)
       end
 
+      # This will be used to add a *to_hash* method override
+      # to each class that *includes* the *PrettyPrint* module.
+      # This will return the class attributes and their values in
+      # a *Hash*.
       def to_hash
         hash = {}
         instance_variables.each do |n|

--- a/lib/shipengine/utils/pretty_print.rb
+++ b/lib/shipengine/utils/pretty_print.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
+require "json"
+
 module ShipEngine
   module Utils
-    class PrettyPrint
-      def self.to_s
+    module PrettyPrint
+      def to_s
+        JSON.pretty_generate(to_hash)
+      end
+
+      def to_hash
         hash = {}
-        instance_variables.each { |n| hash[n.to_s.delete("@")] = instance_variable_get(n) }
+        instance_variables.each do |n|
+          hash[n.to_s.delete("@")] = instance_variable_get(n)
+        end
         hash
       end
     end

--- a/lib/shipengine/utils/pretty_print.rb
+++ b/lib/shipengine/utils/pretty_print.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ShipEngine
+  module Utils
+    class PrettyPrint
+      def self.to_hash
+        hash = {}
+        instance_variables.each { |n| hash[n.to_s.delete("@")] = instance_variable_get(n) }
+        hash
+      end
+    end
+  end
+end

--- a/test/address/normalize_address_functional_test.rb
+++ b/test/address/normalize_address_functional_test.rb
@@ -303,7 +303,7 @@ describe "Normalize Address: Functional" do
   end
 
   # 959
-  it "Should handle multiple merror messages" do
+  it "Should handle multiple error messages" do
     params = {
       street: ["170 Invalid Blvd"],
       city_locality: "Toronto",

--- a/test/package/track_package_test.rb
+++ b/test/package/track_package_test.rb
@@ -40,14 +40,14 @@ describe "track package" do
     )
 
     # The shipmentId is populated,, is not nil, and is a string.
-    assert result.shipment.shipment_id != nil
+    assert !result.shipment.shipment_id.nil?
 
     # The carrier_id is populated, is not nil, and is a string.
-    assert result.shipment.carrier_id != nil, "The carrier_id is populated."
+    assert !result.shipment.carrier_id.nil?, "The carrier_id is populated."
     assert result.shipment.carrier_id.is_a?(String)
 
     # The tracking_number is populated, is not nil, and is a string.
-    assert result.package.tracking_number != nil
+    assert !result.package.tracking_number.nil?
     assert result.package.tracking_number.is_a?(String)
   end
 end

--- a/test/package/track_package_test.rb
+++ b/test/package/track_package_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "track package" do
+  it "DX-993 Tracks a package using a tracking number and carrier code" do
+    tracking_number_valid = "aaaaa_delivered"
+    carrier_code_valid = "fedex"
+
+    client = ::ShipEngine::Client.new("abc1234")
+
+    # The tracking number that's returned matches the tracking number that was specified
+    result = client.track_package_by_tracking_number(tracking_number_valid, carrier_code_valid)
+    p result
+    assert_equal(tracking_number_valid, result.package.tracking_number, "The carrier that's returned matches the carrier code that was specified")
+
+    # # The carrier that's returned matches the carrier code that was specified
+    assert(result.shipment, "shipment should exist")
+    assert_equal(carrier_code_valid, result.shipment.carrier.code, "The package number that's returned matches the carrier code that was specified")
+  end
+end

--- a/test/package/track_package_test.rb
+++ b/test/package/track_package_test.rb
@@ -42,9 +42,9 @@ describe "track package" do
     # The shipmentId is populated, is not nil, and is a string.
     assert !result.shipment.shipment_id.nil?
 
-    # The carrier_id is populated, is not nil, and is a string.
-    assert !result.shipment.carrier_id.nil?, "The carrier_id is populated."
-    assert result.shipment.carrier_id.is_a?(String)
+    # The carrier_account_id is populated, is not nil, and is a string.
+    assert !result.shipment.carrier_account_id.nil?, "The carrier_account_id is populated."
+    assert result.shipment.carrier_account_id.is_a?(String)
 
     # The tracking_number is populated, is not nil, and is a string.
     assert !result.package.tracking_number.nil?

--- a/test/package/track_package_test.rb
+++ b/test/package/track_package_test.rb
@@ -39,7 +39,7 @@ describe "track package" do
       "The packageId that is returned matches the packageId that was specified."
     )
 
-    # The shipmentId is populated,, is not nil, and is a string.
+    # The shipmentId is populated, is not nil, and is a string.
     assert !result.shipment.shipment_id.nil?
 
     # The carrier_id is populated, is not nil, and is a string.
@@ -49,5 +49,20 @@ describe "track package" do
     # The tracking_number is populated, is not nil, and is a string.
     assert !result.package.tracking_number.nil?
     assert result.package.tracking_number.is_a?(String)
+  end
+
+  it "DX-1011 Tests packageId not found." do
+    package_id = "pkg_123"
+    expected_err = {
+      source: "shipengine",
+      code: "invalid_identifier",
+      type: "validation",
+      message: "Package ID #{package_id} does not exist.",
+      request_id: :__REGEX_MATCH__,
+    }
+
+    assert_raises_shipengine(::ShipEngine::Exceptions::ValidationError, expected_err) do
+      client.track_package_by_id(package_id)
+    end
   end
 end

--- a/test/package/track_package_test.rb
+++ b/test/package/track_package_test.rb
@@ -1,21 +1,53 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "shipengine"
 
 describe "track package" do
+  client = ::ShipEngine::Client.new("abc1234")
+
   it "DX-993 Tracks a package using a tracking number and carrier code" do
     tracking_number_valid = "aaaaa_delivered"
     carrier_code_valid = "fedex"
 
-    client = ::ShipEngine::Client.new("abc1234")
-
     # The tracking number that's returned matches the tracking number that was specified
     result = client.track_package_by_tracking_number(tracking_number_valid, carrier_code_valid)
     p result
-    assert_equal(tracking_number_valid, result.package.tracking_number, "The carrier that's returned matches the carrier code that was specified")
+    assert_equal(
+      tracking_number_valid,
+      result.package.tracking_number,
+      "The carrier that's returned matches the carrier code that was specified"
+    )
 
-    # # The carrier that's returned matches the carrier code that was specified
+    # The carrier that's returned matches the carrier code that was specified
     assert(result.shipment, "shipment should exist")
-    assert_equal(carrier_code_valid, result.shipment.carrier.code, "The package number that's returned matches the carrier code that was specified")
+    assert_equal(
+      carrier_code_valid,
+      result.shipment.carrier.code,
+      "The package number that's returned matches the carrier code that was specified"
+    )
+  end
+
+  it "DX-995 Tracks a package using a package_Id (label created in ShipEngine)" do
+    package_id = "pkg_1FedExAccepted"
+    result = client.track_package_by_id(package_id)
+
+    # The packageId that's returned matches the packageId that was specified.
+    assert_equal(
+      package_id,
+      result.package.package_id,
+      "The packageId that is returned matches the packageId that was specified."
+    )
+
+    # The shipmentId is populated,, is not nil, and is a string.
+    assert result.shipment.shipment_id != nil
+
+    # The carrier_id is populated, is not nil, and is a string.
+    assert result.shipment.carrier_id != nil, "The carrier_id is populated."
+    assert result.shipment.carrier_id.is_a?(String)
+
+    # The tracking_number is populated, is not nil, and is a string.
+    assert result.package.tracking_number != nil
+    assert result.package.tracking_number.is_a?(String)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require "webmock/minitest"
 require "spy"
 require "minitest/tagz"
 WebMock.enable_net_connect!
-Minitest::Reporters.use!([Minitest::Reporters::ProgressReporter.new])
+# Minitest::Reporters.use!([Minitest::Reporters::ProgressReporter.new])
 
 # bundle exec rake test TAGS=fast
 # bundle exec rake test TAGS=slow

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require "webmock/minitest"
 require "spy"
 require "minitest/tagz"
 WebMock.enable_net_connect!
-# Minitest::Reporters.use!([Minitest::Reporters::ProgressReporter.new])
+Minitest::Reporters.use!([Minitest::Reporters::ProgressReporter.new])
 
 # bundle exec rake test TAGS=fast
 # bundle exec rake test TAGS=slow

--- a/test/test_utility/custom_assertions.rb
+++ b/test/test_utility/custom_assertions.rb
@@ -29,6 +29,15 @@ module CustomAssertions
     end
   end
 
+  # @param expected [Hash]
+  # @param response [::ShipEngine::TrackPackageResult]
+  def assert_track_package_result(expected, actual)
+    raise "no package" unless actual.package
+
+    assert_equal_value("package_id", expected[:package_id], actual.package.package_id) if expected[:package_id]
+    # assert_equal(expected_carrier[:name], actual.carrier.name, "~> carrier.name")
+  end
+
   # @param expected_event [Hash]
   # @param response_event [::ShipEngine::Emitter::ErrorEvent]
   def assert_error_event(expected_event, actual_event)

--- a/test/test_utility/custom_assertions.rb
+++ b/test/test_utility/custom_assertions.rb
@@ -176,7 +176,7 @@ module CustomAssertions
       message: "You have exceeded the rate limit.",
       source: "shipengine",
     }, &block)
-    assert_equal(retries, err.retries, "Rtries should be the same") unless retries.nil?
+    assert_equal(retries, err.retries, "Retries should be the same") unless retries.nil?
   end
 
   # @param expected_messages [Array<Hash>]

--- a/test/test_utility/factory.rb
+++ b/test/test_utility/factory.rb
@@ -3,6 +3,10 @@ require "json"
 
 module Factory
   class << self
+    def valid_package_id_accepted
+      "pkg_1FedAccepted"
+    end
+
     def valid_address_params
       {
         street: ["104 Foo Street"], postal_code: "78751", country: "US"


### PR DESCRIPTION
Tracking Service tests and implementing the usage of the `list_accounts` method to enrich the `Shipment` object in the `TrackPackageResult` object. This **only** happens when tracking by `packageId`.

Implemenatation Details:
-------------------------
- The [TrackPackageShipment Object](https://github.com/ShipEngine/shipengine-ruby/blob/8192335ec7d635693692be8a860c04d4e96034ea/lib/shipengine/domain/package.rb#L14) needs a private class method added to it. This method has to fetch the carrier accounts connected to a given ShipEngine account and find the one that has an `accountID` that matches the `carrierAccountID` in the tracking response from Simengine. 
    - Once a match has been found, we add a [CarrierAccount Object](https://github.com/ShipEngine/shipengine-ruby/blob/a371d3868cbc3c53169f17df6992152991f8c015/lib/shipengine/domain/carriers.rb#L25) and a [Carrier object](https://github.com/ShipEngine/shipengine-ruby/blob/a371d3868cbc3c53169f17df6992152991f8c015/lib/shipengine/domain/carriers.rb#L7) to the Shipment object.

- [DX-995](https://auctane.atlassian.net/browse/DX-995) - Test successful track by packageId.
- [DX-1011](https://auctane.atlassian.net/browse/DX-1011) - Test packageId not found.
