### PR TITLE
unlocked hashie version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     shipengine (0.1.0)
       faraday (~> 1.4)
       faraday_middleware (~> 1.0)
-      hashie (~> 3.4)
+      hashie (>= 3.4)
 
 GEM
   remote: https://rubygems.org/

--- a/shipengine.gemspec
+++ b/shipengine.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.6"
 
-  spec.add_runtime_dependency("hashie", "~> 3.4")
+  spec.add_runtime_dependency("hashie", ">= 3.4")
   spec.add_runtime_dependency("faraday", "~> 1.4")
   spec.add_runtime_dependency("faraday_middleware", "~> 1.0")
 end


### PR DESCRIPTION
Hashie is locked to an old version 3.x which conflicts with other gems using newer hashie versions. There is no reason to keep it locked to 3.x as it works just fine with newer versions as well.