### PR TITLE
fix: Update versioning and prune failed attempts from git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## [1.0.1](https://github.com/ShipEngine/shipengine-ruby/compare/v1.0.0...v1.0.1) (2023-06-15)
-
-
-### Bug Fixes
-
-* [SE-119] Get SDK build working and First Gem published :truck: ([dbba243](https://github.com/ShipEngine/shipengine-ruby/commit/dbba243460e85fbe5b644078a933ca36c5f2c57d))
-* fixup CD ([fcb16ad](https://github.com/ShipEngine/shipengine-ruby/commit/fcb16ada4628dbb330f3c33f0f5ba58bcfe4d8ed))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shipengine_sdk (1.0.1)
+    shipengine_sdk (0.0.0)
       faraday (>= 1.4)
       faraday_middleware (>= 1.0)
       hashie (>= 3.4)

--- a/lib/shipengine/version.rb
+++ b/lib/shipengine/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShipEngine
-  VERSION = '1.0.1'
+  VERSION = '0.0.0'
 end


### PR DESCRIPTION
We needed to enable MFA in our rubygems.org account to be able to publish the gem properly.