### PR TITLE
Added error codes for funding sources errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,25 @@
 
 ## [1.0.4](https://github.com/ShipEngine/shipengine-ruby/compare/v1.0.3...v1.0.4) (2024-01-17)
 
-
 ### Bug Fixes
 
-* change default timeout to 60s ([81bfe73](https://github.com/ShipEngine/shipengine-ruby/commit/81bfe73feb0abc8a87aedb15e9b3935dd33d4da9))
+- change default timeout to 60s ([81bfe73](https://github.com/ShipEngine/shipengine-ruby/commit/81bfe73feb0abc8a87aedb15e9b3935dd33d4da9))
 
 ## [1.0.3](https://github.com/ShipEngine/shipengine-ruby/compare/v1.0.2...v1.0.3) (2023-06-16)
 
-
 ### Bug Fixes
 
-* Update publish to Gem API Key ([3f9c8e5](https://github.com/ShipEngine/shipengine-ruby/commit/3f9c8e5eec8147e2fb1b38a114fa0e2ff24a5f9e))
+- Update publish to Gem API Key ([3f9c8e5](https://github.com/ShipEngine/shipengine-ruby/commit/3f9c8e5eec8147e2fb1b38a114fa0e2ff24a5f9e))
 
 ## [1.0.4]
 
 ### Changes
 
-* increase default timeout from 30s to 60s
+- increase default timeout from 30s to 60s
+
+## [1.0.5]
+
+### Changes
+
+- Added error code FundingSourceMissingConfiguration
+- Added error code FundingSourceError

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shipengine_sdk (1.0.4)
+    shipengine_sdk (1.0.5)
       faraday (>= 1.4)
       faraday_middleware (>= 1.0)
       hashie (>= 3.4)

--- a/lib/shipengine/exceptions/error_code.rb
+++ b/lib/shipengine/exceptions/error_code.rb
@@ -247,7 +247,17 @@ module ShipEngine
         ## ShipEngine only allows you to have one webhook of each type. If you would
         ## like to replace a webhook with a new one please delete the old one fir.
         #   #/
-        WEBHOOK_EVENT_TYPE_CONFLICT: 'webhook_event_type_conflict'
+        WEBHOOK_EVENT_TYPE_CONFLICT: 'webhook_event_type_conflict',
+
+        ##
+        ## Funding source isnt properly configured and can't be used.
+        #   #/
+        FUNDING_SOURCE_MISSING_CONFIGURATION: 'funding_source_missing_configuration',
+
+        ##
+        ## There was an unexpected problem with a funding source.
+        #   #/
+        FUNDING_SOURCE_ERROR: 'funding_source_error'
       }.freeze
     end
   end

--- a/lib/shipengine/exceptions/error_type.rb
+++ b/lib/shipengine/exceptions/error_type.rb
@@ -42,7 +42,11 @@ module ShipEngine
         # that has not yet been assigned a specific error_type. If you receive
         # persistent system errors, then please contact our support or check our API
         # status page to see if there's a known issue.
-        SYSTEM: 'system'
+        SYSTEM: 'system',
+        # General wallet error type.
+        WALLET: 'wallet',
+        # General funding sources error type.
+        FUNDING_SOURCES: 'funding_sources'
       }.freeze
     end
   end

--- a/lib/shipengine/version.rb
+++ b/lib/shipengine/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ShipEngine
-  VERSION = '1.0.4'
+  VERSION = '1.0.5'
 end


### PR DESCRIPTION
There are some common errors while interacting with funding sources that are not handled correctly. Two of them are that when we throw a PreSetupWalletException or a WalletException we return a "An unexpected error occurred" instead of a more understandable error.
JIRA: https://auctane.atlassian.net/browse/ENGINE-7190
ShipEngine: https://github.com/shipstation/shipstation/pull/20482
SE Documentation: https://github.com/ShipEngine/shipengine-api-definition/pull/114